### PR TITLE
feat: [ADC-27326] Adding mime type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ If deploying to an existing environment you may need to change the service name 
 ./init.sh <env> <service_account_name> <trigger_location>
 ```
 - env: the environment
-- service_account_name the name of the service account before the '@' sign (e.g: dapi-files-user-dev)
+- service_account_name the name of the service account before the '@' sign (e.g: malware-scanner)
 - trigger_location.  The location of the trigger.  This should be equal to the bucket location (us-central1, etc)
+
+Example:
+
+```shell
+./init.sh dev malware-scanner us-central1
+```
 
 ### Service Account
 The service account needs Storage Object Admin and Monitoring Metric Writer permissions.  We currently have

--- a/cloudrun-malware-scanner/package-lock.json
+++ b/cloudrun-malware-scanner/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gcs-malware-scanner",
-  "version": "2.3.1",
+  "version": "0.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gcs-malware-scanner",
-      "version": "2.3.1",
+      "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/logging-bunyan": "^5.0.1",
@@ -16,6 +16,7 @@
         "bunyan": "^1.8.15",
         "clamdjs": "^1.0.2",
         "express": "^4.18.2",
+        "file-type": "^16.5.4",
         "google-auth-library": "^9.4.1",
         "http-proxy": "^1.18.1"
       },
@@ -542,6 +543,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -1500,6 +1507,23 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -2131,6 +2155,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -2709,6 +2753,19 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2859,6 +2916,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/require-directory": {
@@ -3191,6 +3264,23 @@
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -3258,6 +3348,23 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tr46": {

--- a/cloudrun-malware-scanner/package.json
+++ b/cloudrun-malware-scanner/package.json
@@ -22,7 +22,8 @@
     "clamdjs": "^1.0.2",
     "express": "^4.18.2",
     "google-auth-library": "^9.4.1",
-    "http-proxy": "^1.18.1"
+    "http-proxy": "^1.18.1",
+    "file-type": "^16.5.4"
   },
   "devDependencies": {
     "eslint": "^8.56.0",

--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -14,6 +14,7 @@
 * limitations under the License.
 */
 
+const FileType = require('file-type');
 const clamd = require('clamdjs');
 const express = require('express');
 const {Storage} = require('@google-cloud/storage');
@@ -65,6 +66,27 @@ const scanner = clamd.createScanner(CLAMD_HOST, CLAMD_PORT);
 const storage = new Storage({userAgent: `cloud-solutions/${
   pkgJson.name}-usage-v${pkgJson.version}`});
 const googleAuth = new GoogleAuth();
+
+// list of invalid content types
+const invalidMimeTypes = [
+  'application/java-archive',
+  'application/octet-stream',
+  'application/postscript',
+  'application/vnd.android.package-archive',
+  'application/vnd.ms-cab-compressed',
+  'application/vnd.palm',
+  'application/vnd.sqlite3',
+  'application/x-dosexec',
+  'application/x-httpd-php',
+  'application/x-iso9660-image',
+  'application/x-msaccess',
+  'application/x-msdownload',
+  'application/x-perl',
+  'application/x-sh',
+  'application/x-tar',
+  'text/x-c',
+  'text/x-script.python',
+];
 
 /**
  * Route that is invoked by Cloud Run when a malware scan is requested
@@ -133,12 +155,41 @@ async function handleGcsObject(req, res) {
     }
 
     const gcsFile = storage.bucket(file.bucket).file(file.name);
+
     // File.exists() returns a FileExistsResponse, which is a list with a
     // single value.
     if (! (await gcsFile.exists())[0]) {
       // Warn but return successful to client.
       logger.warn(`Ignoring no longer existing file: gs://${file.bucket}/${file.name}`);
       res.json({status: 'deleted'});
+      return;
+    }
+
+    // Get the file mime type using file-type lib
+    const mimeTypeReadStream = gcsFile.createReadStream();
+    let fileType;
+    try {
+      fileType = await FileType.fromStream(mimeTypeReadStream);
+    } finally {
+      mimeTypeReadStream.destroy(); // Destroy stream after detection to prevent resource leaks
+    }
+
+    // only check the mime type if it's available
+    if (fileType && fileType.mime && invalidMimeTypes.includes(fileType.mime)) {
+
+      logger.info(`Mime type for gs://${file.bucket}/${file.name}: ${fileType.mime}`);
+
+      const msg = `Found invalid mime type for for gs://${file.bucket}/${file.name}: ${fileType.mime}.`
+      logger.info(msg);
+
+      // Move the file with the invalid content type to the quarantine bucket
+      await moveProcessedFile(file.name, false, config);
+
+      // Respond to API client.
+      res.json({
+        message: msg,
+        status: 'invalid content type'
+      });
       return;
     }
 
@@ -309,6 +360,9 @@ async function moveProcessedFile(filename, isClean, config) {
   const srcfile = storage.bucket(config.unscanned).file(filename);
   const destinationBucketName =
       isClean ? `gs://${config.clean}` : `gs://${config.quarantined}`;
+
+  logger.info(`Moving ${filename} to: ${destinationBucketName}`)
+
   const destinationBucket = storage.bucket(destinationBucketName);
   await srcfile.move(destinationBucket);
 }


### PR DESCRIPTION
This code provides an implementation for checking for invalid mime types in our ClamAV scanner by comparing the file metadata against a known invalid mime type list:

- `application/java-archive`
- `application/octet-stream`
- `application/postscript`
- `application/vnd.android.package-archive`
- `application/vnd.ms-cab-compressed`
- `application/vnd.palm`
- `application/vnd.sqlite3`
- `application/x-httpd-php`
- `application/x-iso9660-image`
- `application/x-msaccess`
- `application/x-msdownload`
- `application/x-perl`
- `application/x-sh`
- `application/x-tar`
- `text/x-c`
- `text/x-script.python`

---

### JIRA:
https://adcellerant.atlassian.net/browse/ADC-27326

---